### PR TITLE
Enhance README with detailed setup instructions and a 'More Details' dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@
 <details>
   <summary><b>&nbsp;&nbsp;More Details</b></summary>
   <br/>
-  <p ## 🔑 Authentication & Permissions  
-To allow GitHub Actions to commit and push changes, follow these steps:
+  <p> 
 
-### 📝 Setting Up Personal Access Token (PAT)  
+### 🔑 Authentication & Permissions  
+To allow GitHub Actions to commit and push changes, follow these steps:
+### Setting Up Personal Access Token (PAT)  
 1️⃣ Go to **Settings** → **Developer settings** → **Personal access tokens**.  
 2️⃣ Click on **Generate a new token (classic)**.  
 3️⃣ Select the required scopes:  
@@ -32,7 +33,7 @@ To allow GitHub Actions to commit and push changes, follow these steps:
  
 **⚠️ Important:** Copy the token as it will disappear once you leave the page.  
 
-### 🔒 Adding the Token as a Secret  
+### Adding the Token as a Secret  
 1️⃣ Go to **Repository Settings** → **Secrets and Variables** → **Actions**.  
 2️⃣ Click **New Repository Secret**.  
 3️⃣ Name it **GHT** and paste the copied PAT in the input box.  
@@ -40,7 +41,7 @@ To allow GitHub Actions to commit and push changes, follow these steps:
 
 **⚠️ Security Tip:** Never expose your PAT publicly. Store it securely as it grants repo modification permissions.  
 
-### ⚙️ Grant Workflow Permissions  
+### Grant Workflow Permissions  
 1️⃣ Go to your **GitHub Repository Settings**.  
 2️⃣ Navigate to **Actions** under **Code and Automation**.  
 3️⃣ Select **General** from the dropdown.  
@@ -50,13 +51,13 @@ To allow GitHub Actions to commit and push changes, follow these steps:
 
 ---  
 
-## ▶️ Running Workflows  
-🎯 **Manual Execution**  
+## Running Workflows  
+ **Manual Execution**  
 1️⃣ Navigate to the **Actions** tab in your repository.  
 2️⃣ Under **All Workflows**, select the `main.yml` file to run.  
 3️⃣ Click **Run Workflow** to manually trigger the workflow for testing.  
 
-⏳ **Automated Execution**  
+ **Automated Execution**  
 The workflows are scheduled to run **automatically at defined UTC times**.  
 After a successful run, your generated files can be embedded into your **README** file. 📄 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,51 @@
 2. Create the personal access token. Checkout this [link](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to create a personal access token.
 3. Add a new repository secret to your repo. The name of the secret must be `GHT` and the value is your personal access token (PAT). Checkout this [link](https://docs.github.com/en/actions/reference/encrypted-secrets) to add a new repository secret.
 4. Enable `Allow GitHub Actions to create and approve pull requests` in General Action Settings
+<details>
+  <summary><b>&nbsp;&nbsp;More Details</b></summary>
+  <br/>
+  <p ## 🔑 Authentication & Permissions  
+To allow GitHub Actions to commit and push changes, follow these steps:
+
+### 📝 Setting Up Personal Access Token (PAT)  
+1️⃣ Go to **Settings** → **Developer settings** → **Personal access tokens**.  
+2️⃣ Click on **Generate a new token (classic)**.  
+3️⃣ Select the required scopes:  
+   - ✅ `repo` → Full control of private repositories.  
+   - ✅ `workflow` → Allows GitHub Actions to trigger workflows.
+ 
+**⚠️ Important:** Copy the token as it will disappear once you leave the page.  
+
+### 🔒 Adding the Token as a Secret  
+1️⃣ Go to **Repository Settings** → **Secrets and Variables** → **Actions**.  
+2️⃣ Click **New Repository Secret**.  
+3️⃣ Name it **GHT** and paste the copied PAT in the input box.  
+4️⃣ Save it.  
+
+**⚠️ Security Tip:** Never expose your PAT publicly. Store it securely as it grants repo modification permissions.  
+
+### ⚙️ Grant Workflow Permissions  
+1️⃣ Go to your **GitHub Repository Settings**.  
+2️⃣ Navigate to **Actions** under **Code and Automation**.  
+3️⃣ Select **General** from the dropdown.  
+4️⃣ Scroll down to **Workflow Permissions**.  
+5️⃣ Choose **Read and write permissions**.  
+6️⃣ Save the settings. ✅  
+
+---  
+
+## ▶️ Running Workflows  
+🎯 **Manual Execution**  
+1️⃣ Navigate to the **Actions** tab in your repository.  
+2️⃣ Under **All Workflows**, select the `main.yml` file to run.  
+3️⃣ Click **Run Workflow** to manually trigger the workflow for testing.  
+
+⏳ **Automated Execution**  
+The workflows are scheduled to run **automatically at defined UTC times**.  
+After a successful run, your generated files can be embedded into your **README** file. 📄 </p>
+
+</details>
+
 
 The file `github_stats.svg` is an svg image of your github stats. You can copy the link of the image and use it anywhere. By default it updates daily at `2:47 UTC`. You can also change this by changing the cron in `/.github/workflows/main.yml` by using [Cron Generator](https://crontab.guru/).
 


### PR DESCRIPTION
I found the original setup instructions slightly unclear, especially for newcomers like me who are unfamiliar with GitHub Actions and repository secrets. To make the setup process more accessible, I have:

- Added a 'More Details' dropdown under the Usage section to provide an in-depth guide.
- Included step-by-step instructions for setting up Personal Access Tokens (PAT), adding repository secrets, and granting workflow permissions.
- Clarified manual vs. automated workflow execution to help users understand how to trigger the GitHub Actions workflow effectively.
- Ensured security best practices are mentioned, such as keeping the PAT secure.